### PR TITLE
Update install directions to prevent sbt deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or remove the generated stub `build.sbt` and just use the generate source tree
 
 In most cases a global installation will make the most sense as the target usage for this plugin is the creation of new projects
 
-If you have a `~/.sbt` directory created, in a `~/.sbt/plugins/build.sbt` file add the following
+If you have a `~/project` directory created, in a `~/project/build.sbt` file add the following
 
     addSbtPlugin("me.lessis" % "np" % "0.2.0")
 


### PR DESCRIPTION
This is pretty trivial. The directions in the current README.md work correctly, but it causes two sbt deprecation warnings with sbt 0.12.0; the first, for using ~/.sbt instead of ~/project, and the second for using a plugins directory, rather than the project directory, if we do `mv ~/.sbt ~/project`
