### PR TITLE
Ensure build.sbt ends in newline

### DIFF
--- a/src/main/scala/np.scala
+++ b/src/main/scala/np.scala
@@ -25,12 +25,13 @@ private object BuildSbt {
     |
     |name := "%s"
     |
-    |version %s""".stripMargin.format(
+    |version %s
+    |""".stripMargin.format(
       if(plugin) "sbtPlugin := true\n\n" else "",
       org,
       name,
       versionBind(version, plugin)
-    ).trim()
+    )
 }
 
 private object Usage {


### PR DESCRIPTION
Rationale: Unix tools (including git) hate files which don't end with a newline.

To allow this, remove the call to trim(). I verified that the resulting
build.sbt contains no superfluous whitespace. In fact, before this
commit trim had no effect since its argument was already trimmed.
