### PR TITLE
Changed all tests 'context' task to better handle lines.

### DIFF
--- a/src/sbt-test/np/cross-sbt-plugin/build.sbt
+++ b/src/sbt-test/np/cross-sbt-plugin/build.sbt
@@ -5,7 +5,7 @@ InputKey[Unit]("contents") <<= inputTask { (argsTask: TaskKey[Seq[String]]) =>
     (args, out) =>
       args match {
         case Seq(given, expected) =>
-          if(IO.read(file(given)).trim.equals(IO.read(file(expected)).trim)) out.log.debug(
+          if(IO.readLines(file(given)).equals(IO.readLines(file(expected)))) out.log.debug(
             "Contents match"
           )
           else error(

--- a/src/sbt-test/np/custom-defaults/build.sbt
+++ b/src/sbt-test/np/custom-defaults/build.sbt
@@ -10,7 +10,7 @@ InputKey[Unit]("contents") <<= inputTask { (argsTask: TaskKey[Seq[String]]) =>
     (args, out) =>
       args match {
         case Seq(given, expected) =>
-          if(IO.read(file(given)).trim.equals(IO.read(file(expected)).trim)) out.log.debug(
+          if(IO.readLines(file(given)).equals(IO.readLines(file(expected)))) out.log.debug(
             "Contents match"
           )
           else error(

--- a/src/sbt-test/np/simple/build.sbt
+++ b/src/sbt-test/np/simple/build.sbt
@@ -5,7 +5,7 @@ InputKey[Unit]("contents") <<= inputTask { (argsTask: TaskKey[Seq[String]]) =>
     (args, out) =>
       args match {
         case Seq(given, expected) =>
-          if(IO.read(file(given)).trim.equals(IO.read(file(expected)).trim)) out.log.debug(
+          if(IO.readLines(file(given)).equals(IO.readLines(file(expected)))) out.log.debug(
             "Contents match"
           )
           else error(


### PR DESCRIPTION
I made this change because new lines are different between operating systems. I've copied this task to a project of my own and encountered this problem, so now I discard the differences between new lines.

Changing to IO.readLines fixed my problem, maybe it can help others as well.
